### PR TITLE
Fixed a handful of warnings and added LUA_REG_NO_DLL define for embed…

### DIFF
--- a/src/lua_int64.h
+++ b/src/lua_int64.h
@@ -24,7 +24,11 @@ int atoINT64(const char* s, INT64 *pv);
 #define lua_pushUINT64(L,n)	\
 	if( n > CONST_9007199254740992 ){ \
 		char buf[24]; \
-		lua_pushstring(L, _ui64toa(n, buf, 10)); \
+		if(_ui64toa_s(n, buf, _countof(buf), 10)){ \
+			lua_pushnil(L);return; \
+		}else{ \
+		lua_pushstring(L, buf); \
+		} \
 	}else{ \
 		lua_pushnumber(L, (lua_Number)(__int64)n); \
 	}

--- a/src/lua_mtutil.h
+++ b/src/lua_mtutil.h
@@ -7,7 +7,7 @@ extern "C" {
 #include <lualib.h>
 #include <lauxlib.h>
 
-int lua_opentablemt(lua_State *L, const char * libname, const luaL_Reg * reg);
+int lua_opentablemt(lua_State *L, const char * libname, const luaL_Reg * reg, int upval);
 void * lua_newuserdatamt(lua_State *L, size_t cdata, const char * mtname, const luaL_Reg * mtreg);
 void * lua_newuserdatamtuv(lua_State *L, size_t cdata, const char * mtname, const luaL_Reg * mtreg, int upval);
 #ifdef  __cplusplus


### PR DESCRIPTION
Fixed a handful of warnings and added LUA_REG_NO_DLL define for embedding the library without DLL.

This fixes a handful of warnings. In particular I am now using the safer `_ui64toa_s` as opposed to `_ui64toa` and checking the result. And if it fails `nil` is pushed instead of the retrieved value.

Furthermore I added a missing argument to the `lua_opentablemt` declaration in the header.

`lua_assert` is conditionally defined now. Probably not something that is absolutely needed, but it does offer flexibility.

The define `LUA_REG_NO_DLL` can be used to hide `DllMain` and make `luaopen_winreg` a simple `extern` function.

`_stricmp` is being used instead of `stricmp` again, but a better approach would be to check for whatever old MSC version has been used for some of the builds and `#define _stricmp stricmp` there (or something along those lines).

The functions that shouldn't be available with `LUA_REG_NO_HIVEOPS` defined are now conditionally excluded if `LUA_REG_NO_HIVEOPS` is defined.