### PR TITLE
Fixed a handful of warnings with Visual C++ and added some defines

### DIFF
--- a/src/lua_int64.h
+++ b/src/lua_int64.h
@@ -24,7 +24,11 @@ int atoINT64(const char* s, INT64 *pv);
 #define lua_pushUINT64(L,n)	\
 	if( n > CONST_9007199254740992 ){ \
 		char buf[24]; \
-		lua_pushstring(L, _ui64toa(n, buf, 10)); \
+		if(_ui64toa_s(n, buf, _countof(buf), 10)){ \
+			lua_pushnil(L);return; \
+		}else{ \
+		lua_pushstring(L, buf); \
+		} \
 	}else{ \
 		lua_pushnumber(L, (lua_Number)(__int64)n); \
 	}

--- a/src/lua_int64.h
+++ b/src/lua_int64.h
@@ -15,6 +15,10 @@ INT64 lua_checkINT64(lua_State *L, int i);
 int atoUINT64(const char* s, UINT64 * pv);
 int atoINT64(const char* s, INT64 *pv);
 
+#ifndef MINGW_HAS_SECURE_API
+#define _ui64toa_s(val, buf, sz, radix) !_ui64toa(val, buf, radix)
+#endif
+
 #ifdef __GNUC__
 	#define CONST_9007199254740992 0x20000000000000LL
 #else

--- a/src/lua_mtutil.h
+++ b/src/lua_mtutil.h
@@ -7,7 +7,7 @@ extern "C" {
 #include <lualib.h>
 #include <lauxlib.h>
 
-int lua_opentablemt(lua_State *L, const char * libname, const luaL_Reg * reg);
+int lua_opentablemt(lua_State *L, const char * libname, const luaL_Reg * reg, int upval);
 void * lua_newuserdatamt(lua_State *L, size_t cdata, const char * mtname, const luaL_Reg * mtreg);
 void * lua_newuserdatamtuv(lua_State *L, size_t cdata, const char * mtname, const luaL_Reg * mtreg, int upval);
 #ifdef  __cplusplus

--- a/src/luareg.h
+++ b/src/luareg.h
@@ -15,13 +15,19 @@ int reg_enumvalue(lua_State *L);
 int reg_flushkey(lua_State *L);
 int reg_getinfo(lua_State *L);
 int reg_getvalue(lua_State *L);
+#ifndef LUA_REG_NO_HIVEOPS
 int reg_loadkey(lua_State *L);
+#endif // LUA_REG_NO_HIVEOPS
 int reg_openkey(lua_State *L);
+#ifndef LUA_REG_NO_HIVEOPS
 int reg_replacekey(lua_State *L);
 int reg_restorekey(lua_State *L);
 int reg_savekey(lua_State *L);
+#endif // LUA_REG_NO_HIVEOPS
 int reg_setvalue(lua_State *L);
+#ifndef LUA_REG_NO_HIVEOPS
 int reg_unloadkey(lua_State *L);
+#endif // LUA_REG_NO_HIVEOPS
 int reg_handle(lua_State *L);
 int reg_detach(lua_State *L);
 int reg_getstrval(lua_State *L);
@@ -41,13 +47,19 @@ luaL_Reg lreg_regobj[] = {
 {"flushkey",reg_flushkey},
 {"getinfo",reg_getinfo},
 {"getvalue",reg_getvalue},
+#ifndef LUA_REG_NO_HIVEOPS
 {"load",reg_loadkey},
+#endif // LUA_REG_NO_HIVEOPS
 {"openkey",reg_openkey},
+#ifndef LUA_REG_NO_HIVEOPS
 {"replace",reg_replacekey},
 {"restore",reg_restorekey},
 {"save",reg_savekey},
+#endif // LUA_REG_NO_HIVEOPS
 {"setvalue",reg_setvalue},
+#ifndef LUA_REG_NO_HIVEOPS
 {"unload",reg_unloadkey},
+#endif // LUA_REG_NO_HIVEOPS
 {"handle",reg_handle},
 {"detach",reg_detach},
 {"getstrval",reg_getstrval},

--- a/src/win_trace.h
+++ b/src/win_trace.h
@@ -17,7 +17,13 @@ extern "C" {
 #endif
 
 #include <windows.h>
-#ifdef NDEBUG
+#if defined(NDEBUG) && (defined(__MINGW32__) || (defined(_MSC_VER) && (_MSC_VER >= 1400)))
+	#define WIN_TRACET(...) do {} while(0)
+	#define WIN_TRACEA(...) do {} while(0)
+	#define WIN_TRACEW(...) do {} while(0)
+	#define WIN_TRACEA_FT(...) do {} while(0)
+	#define WIN_TRACEA_ST(...) do {} while(0)
+#elif defined(NDEBUG) && defined(_MSC_VER) && (_MSC_VER < 1400)
 	#define WIN_TRACET NOP_FUNCTION
 	#define WIN_TRACEA NOP_FUNCTION
 	#define WIN_TRACEW NOP_FUNCTION

--- a/src/winreg.c
+++ b/src/winreg.c
@@ -2,7 +2,7 @@
 #	include <luamsvc.h>
 #endif
 
-#include <stdlib.h> /* _ui64toa_s */
+#include <stdlib.h> /* _ui64toa/_ui64toa_s */
 #include <assert.h>
 #ifndef lua_assert
 #define lua_assert assert

--- a/src/winreg.c
+++ b/src/winreg.c
@@ -39,6 +39,13 @@
 #define REG_QWORD                   ( 11 )  // 64-bit number
 #endif
 
+#if !defined(KEY_WOW64_32KEY) && defined(__MINGW32__)
+#define KEY_WOW64_32KEY         (0x0200)
+#endif
+#if !defined(KEY_WOW64_64KEY) && defined(__MINGW32__)
+#define KEY_WOW64_64KEY         (0x0100)
+#endif
+
 #ifndef LUA_REG_NO_DLL
 BOOL APIENTRY DllMain(HANDLE hModule, DWORD  ul_reason_for_call,  LPVOID lpReserved){
 	UNUSED(hModule);

--- a/src/winreg.c
+++ b/src/winreg.c
@@ -2,6 +2,7 @@
 #	include <luamsvc.h>
 #endif
 
+#include <stdlib.h> /* _ui64toa_s */
 #include <assert.h>
 #ifndef lua_assert
 #define lua_assert assert


### PR DESCRIPTION
* The use of `_ui64toa` caused a warning in `lua_int64.h`, which could be fixed by replacing the call by one to `_ui64toa_s`. Also, this now handles failures to convert gracefully, although your mileage may vary and you may want a different kind of handling there. A second instance of this issue occurred in `winreg.c` and was fixed there.
* While `lua_opentablemt` is a C function and thus takes a variable number of parameters, I got a warning because it was missing the `upval` argument which was given on the definition, but not the declaration.
* I needed the `#ifndef lua_assert` in order to work around some issues when using the C preprocessor to _include_ the `winreg.c` file.
* Defining `LUA_REG_NO_DLL` now allows to get rid of the `DllMain` and the `__declspec(dllexport)` on the exported function.
* Furthermore defining `LUA_REG_NO_HIVEOPS` allows to suppress the Lua functions which can be used for hive operations such as loading and unloading a registry key.
* One instance of using `stricmp` instead of `_stricmp` was also fixed.

The patches are pretty straightforward, so feel free to pull them into master or don't. I just want to offer them this way.

Thanks for your module!

Best regards,

Oliver